### PR TITLE
Fix passed arguments to pack_job

### DIFF
--- a/src/toil_batch_system_tes/tes_batch_system.py
+++ b/src/toil_batch_system_tes/tes_batch_system.py
@@ -42,6 +42,7 @@ from toil.common import Config, Toil
 from toil.job import JobDescription
 from toil.lib.misc import get_public_ip, slow_down, utc_now
 from toil.resource import Resource
+from toil.statsAndLogging import set_log_level
 
 logger = logging.getLogger(__name__)
 
@@ -71,6 +72,7 @@ class TESBatchSystem(BatchSystemCleanupSupport):
 
     def __init__(self, config: Config, maxCores: float, maxMemory: int, maxDisk: int) -> None:
         super().__init__(config, maxCores, maxMemory, maxDisk)
+        set_log_level(config.logLevel, logger)
         # Connect to TES, using Funnel-compatible environment variables to fill in credentials if not specified.
         tes_endpoint = config.tes_endpoint or self.get_default_tes_endpoint()
         self.tes = tes.HTTPClient(tes_endpoint,
@@ -188,7 +190,7 @@ class TESBatchSystem(BatchSystemCleanupSupport):
                 environment['TOIL_WORKDIR'] = '/tmp'
 
             # Make a command to run it in the executor
-            command_list = pack_job(command, job_desc, self.user_script)
+            command_list = pack_job(command, self.user_script)
 
             # Make the sequence of TES containers ("executors") to run.
             # We just run one which is the Toil executor to grab the user


### PR DESCRIPTION
We [changed the internal API for pack_job](https://github.com/DataBiosphere/toil/commit/8438f73417583bb89e436cbfe60dd644b6ca94aa#diff-6bd5c3df1db3a53981662d259d2b3fce14d3f09d22f6b3c8e2cc04668b18f423) a while ago, which the TES batch system plugin hadn't reflected yet and thus passed in the wrong object into `pack_job`, resulting in `register()` being called on an object that had no corresponding function.

Also adds logging to the plugin so the user can see when and how it is loading